### PR TITLE
Merge Kaffe into Om page; remove Kaffe nav item

### DIFF
--- a/src/app/kaffe/page.tsx
+++ b/src/app/kaffe/page.tsx
@@ -1,28 +1,5 @@
-import { getBirds } from '@/lib/data/birds'
-import QuizHeader from '@/components/quiz/QuizHeader'
-import MobileBottomNav from '@/components/quiz/MobileBottomNav'
+import { redirect } from 'next/navigation'
 
-export default async function DonerePage() {
-  // Get birds for consistency (even though not used yet)
-  await getBirds()
-
-  return (
-    <div className="quiz-app-root">
-      <div id="secondary-screen" className="screen active">
-        <QuizHeader activePage="quiz" />
-
-        <div className="secondary-content">
-          <div className="secondary-container">
-            <h1 className="secondary-title">Giv en kaffe ☕</h1>
-
-            <div className="secondary-card">
-              <p>Indhold kommer snart...</p>
-            </div>
-          </div>
-        </div>
-
-        <MobileBottomNav activePage="kaffe" />
-      </div>
-    </div>
-  )
+export default function KaffePage() {
+  redirect('/om')
 }

--- a/src/app/om/page.tsx
+++ b/src/app/om/page.tsx
@@ -1,28 +1,46 @@
-import { getBirds } from '@/lib/data/birds'
+import '@/components/quiz/quiz.css'
 import QuizHeader from '@/components/quiz/QuizHeader'
 import MobileBottomNav from '@/components/quiz/MobileBottomNav'
 
-export default async function OmPage() {
-  // Get birds for consistency (even though not used yet)
-  await getBirds()
-
+export default function OmPage() {
   return (
-    <div className="quiz-app-root">
+    <>
+      <QuizHeader />
       <div id="secondary-screen" className="screen active">
-        <QuizHeader activePage="quiz" />
+        <div className="secondary-page-content">
+          <div>
+            <h1 style={{ fontSize: 'var(--quiz-text-2xl)', fontWeight: 700, color: 'var(--quiz-foreground)' }}>
+              Om Fugle Quiz
+            </h1>
+          </div>
 
-        <div className="secondary-content">
-          <div className="secondary-container">
-            <h1 className="secondary-title">Om Fugle Quiz</h1>
+          <div className="result-card" style={{ padding: 'var(--quiz-padding-md)' }}>
+            <p style={{ color: 'var(--quiz-text-secondary)', fontSize: 'var(--quiz-text-base)', lineHeight: 1.6 }}>
+              Fugle Quiz er en gratis dansk fuglequiz, der hjælper dig med at lære de danske fugle at kende.
+              Gæt fuglen ud fra billeder og lyd, og se hvordan du klarer dig mod andre.
+            </p>
+          </div>
 
-            <div className="secondary-card">
-              <p>Indhold kommer snart...</p>
-            </div>
+          <div className="result-card" style={{ padding: 'var(--quiz-padding-md)' }}>
+            <p className="setting-label" style={{ marginBottom: 'var(--quiz-gap-sm)' }}>Kontakt</p>
+            <a
+              href="mailto:hallo@magnify.dk"
+              style={{ color: 'var(--quiz-accent)', fontSize: 'var(--quiz-text-base)' }}
+            >
+              hallo@magnify.dk
+            </a>
+          </div>
+
+          <div className="result-card" style={{ padding: 'var(--quiz-padding-md)' }}>
+            <p className="setting-label" style={{ marginBottom: 'var(--quiz-gap-sm)' }}>Støt projektet</p>
+            <p style={{ color: 'var(--quiz-text-secondary)', fontSize: 'var(--quiz-text-base)', lineHeight: 1.6 }}>
+              Kan du lide Fugle Quiz? Send en kaffe via MobilePay:{' '}
+              <strong style={{ color: 'var(--quiz-foreground)' }}>XXXX</strong>
+            </p>
           </div>
         </div>
-
-        <MobileBottomNav activePage="om" />
       </div>
-    </div>
+      <MobileBottomNav activePage="om" />
+    </>
   )
 }

--- a/src/components/quiz/MobileBottomNav.tsx
+++ b/src/components/quiz/MobileBottomNav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 interface MobileBottomNavProps {
-  activePage?: 'home' | 'resultater' | 'rangliste' | 'om' | 'kaffe'
+  activePage?: 'home' | 'resultater' | 'rangliste' | 'om'
   isQuizActive?: boolean
   onNavClick?: (href: string) => void
 }
@@ -63,25 +63,6 @@ export default function MobileBottomNav({ activePage, isQuizActive = false, onNa
           <path d="M12 8h.01"/>
         </svg>
         <span className="mobile-nav-label">Om</span>
-      </a>
-      <a
-        href="/kaffe"
-        className={`mobile-nav-item ${activePage === 'kaffe' ? 'active' : ''}`}
-        onClick={(e) => {
-          if (isQuizActive && onNavClick) {
-            e.preventDefault()
-            onNavClick('/kaffe')
-          }
-        }}
-      >
-        <svg className="mobile-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M17 8h1a4 4 0 1 1 0 8h-1"/>
-          <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/>
-          <line x1="6" y1="2" x2="6" y2="4"/>
-          <line x1="10" y1="2" x2="10" y2="4"/>
-          <line x1="14" y1="2" x2="14" y2="4"/>
-        </svg>
-        <span className="mobile-nav-label">Kaffe</span>
       </a>
     </nav>
   )

--- a/src/components/quiz/quiz.css
+++ b/src/components/quiz/quiz.css
@@ -268,15 +268,17 @@
 @media (max-width: 640px) {
   .mobile-bottom-nav {
     position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    bottom: var(--quiz-gap-md);
+    left: var(--quiz-gap-md);
+    right: var(--quiz-gap-md);
     z-index: 100;
-    background: rgba(15, 26, 20, 0.95);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border-top: 1px solid var(--quiz-border);
-    padding: var(--quiz-gap-xs) 0;
+    background: color-mix(in srgb, var(--quiz-bg-secondary) 92%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--quiz-border);
+    border-radius: var(--quiz-radius-pill);
+    box-shadow: 0 4px 24px color-mix(in srgb, var(--quiz-background) 40%, transparent);
+    padding: var(--quiz-gap-xs);
     display: flex;
     justify-content: space-around;
     gap: 0;
@@ -291,15 +293,17 @@
     padding: var(--quiz-gap-xs) var(--quiz-gap-sm);
     text-decoration: none;
     color: var(--quiz-text-muted);
-    transition: color var(--quiz-transition);
+    border-radius: var(--quiz-radius-md);
+    transition: color var(--quiz-transition), background-color var(--quiz-transition);
   }
 
-  .mobile-nav-item:active {
-    opacity: 0.7;
+  .mobile-nav-item:hover {
+    color: var(--quiz-accent);
   }
 
   .mobile-nav-item.active {
     color: var(--quiz-accent);
+    background: var(--quiz-accent-glow);
   }
 
   .mobile-nav-icon {
@@ -315,12 +319,12 @@
     letter-spacing: 0;
   }
 
-  /* Adjust screens to account for bottom nav */
+  /* Adjust screens to account for floating pill nav */
   #start-screen,
   #secondary-screen,
   #my-results-screen,
   #leaderboard-screen {
-    padding-bottom: 60px;
+    padding-bottom: 76px;
   }
 }
 
@@ -2068,4 +2072,3 @@ details.results-missed[open] .missed-summary {
     font-size: 0.85rem;
   }
 }
-


### PR DESCRIPTION
## Summary

- **`/om`** — replaces placeholder with three cards: about text, contact (`hallo@magnify.dk`), and MobilePay support (placeholder `XXXX`)
- **`/kaffe`** — server-side redirect to `/om` so old links don't 404
- **`MobileBottomNav`** — Kaffe item removed; `activePage` type narrowed from 5 to 4 values

## Test plan

- [ ] `/om` shows about, contact, and support cards with correct styling
- [ ] `/kaffe` redirects to `/om`
- [ ] Mobile bottom nav shows 3 items (Resultater, Rangliste, Om) — no Kaffe
- [ ] "Om" nav item highlights correctly when on `/om`
- [ ] TypeScript compiles clean (no remaining `'kaffe'` in activePage type)

https://claude.ai/code/session_01XiufsQqDCnX7aCgMrpHVj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiufsQqDCnX7aCgMrpHVj4)_